### PR TITLE
[#15] Create New Tag Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For reference, the final step is to [publish it on the Terraform Registry](https
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
 - [Go](https://golang.org/doc/install) >= 1.21
+- [jq](https://stedolan.github.io/jq/download/) >= 1.7.1
 
 ## Building The Provider
 

--- a/examples/tags/main.tf
+++ b/examples/tags/main.tf
@@ -11,8 +11,20 @@ provider "statsig" {
   console_api_key = "console-*"
 }
 
-data "statsig_tags" "all" {}
+data "statsig_tags" "all" {
+  depends_on = [statsig_tag.test]
+}
 
 output "all_tags" {
   value = data.statsig_tags.all.tags
+}
+
+resource "statsig_tag" "test" {
+  name        = "test_tf"
+  description = "test tag created in terraform"
+  is_core     = false
+}
+
+output "test_tag" {
+  value = statsig_tag.test
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,7 +50,7 @@ func (p *StatsigProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 				Required:    true,
 				Description: "A Statsig Console API Key",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^console-.*"), "Provided key is not a valid Console API key"),
+					stringvalidator.RegexMatches(regexp.MustCompile("^console-[a-zA-Z0-9]{3,}"), "Provided key is not a valid Console API key"),
 				},
 			},
 		},

--- a/internal/service/tags/resource.go
+++ b/internal/service/tags/resource.go
@@ -1,0 +1,203 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/useless-solutions/terraform-provider-statsig/internal/statsig"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var (
+	_ resource.Resource                = &TagResource{}
+	_ resource.ResourceWithImportState = &TagResource{}
+	_ resource.ResourceWithConfigure   = &TagResource{}
+)
+
+func NewTagResource() resource.Resource {
+	return &TagResource{}
+}
+
+// TagResource defines the resource implementation.
+type TagResource struct {
+	client *statsig.Client
+}
+
+func (r *TagResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tag"
+}
+
+func (r *TagResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Create a tag in the Statsig Project.",
+
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The display name of the new tag",
+				Required:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "The description of this tag",
+				Required:            true,
+			},
+			"is_core": schema.BoolAttribute{
+				MarkdownDescription: "Whether or not the tag is a Core tag",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the tag",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *TagResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*statsig.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *statsig.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan Tag
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Map the Terraform plan data to the API request model
+	apiReq := statsig.TagAPIRequest{
+		Name:        plan.Name.ValueString(),
+		Description: plan.Description.ValueString(),
+		IsCore:      plan.IsCore.ValueBool(),
+	}
+
+	// Create the tag
+	tag, err := r.client.CreateTag(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to create tag, got error: %s", err),
+		)
+		return
+	}
+
+	// Update the plan attributes with the tag attributes
+	tflog.Debug(ctx, fmt.Sprintf("Updating plan with created tag. Currently: %+v", plan))
+	plan = Tag{
+		ID:          types.StringValue(tag.ID),
+		Name:        types.StringValue(tag.Name),
+		Description: types.StringValue(tag.Description),
+		IsCore:      types.BoolValue(tag.IsCore),
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Updated plan with created tag. Now: %+v", plan))
+
+	tflog.Trace(ctx, fmt.Sprintf("Tag created with ID: %s", plan.ID))
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// TODO: Functionality doesn't exist in API. Might be able to hack it with read ALL tags and filter by ID/name.
+func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data statsig.TagAPIRequest
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If applicable, this is a great opportunity to initialize any necessary
+	// provider client data and make a call using it.
+	// httpResp, err := r.client.Do(httpReq)
+	// if err != nil {
+	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
+	//     return
+	// }
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// TODO: Functionality not supported in API. Will likely delete this.
+func (r *TagResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data statsig.TagAPIRequest
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If applicable, this is a great opportunity to initialize any necessary
+	// provider client data and make a call using it.
+	// httpResp, err := r.client.Do(httpReq)
+	// if err != nil {
+	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, got error: %s", err))
+	//     return
+	// }
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// TODO: Functionality not supported in API. Will likely delete this.
+func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data statsig.TagAPIRequest
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If applicable, this is a great opportunity to initialize any necessary
+	// provider client data and make a call using it.
+	// httpResp, err := r.client.Do(httpReq)
+	// if err != nil {
+	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete example, got error: %s", err))
+	//     return
+	// }
+}
+
+// TODO: Need to test this functionality
+func (r *TagResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/statsig/statsig_client.go
+++ b/internal/statsig/statsig_client.go
@@ -18,6 +18,17 @@ type Client struct {
 	Client   *http.Client
 }
 
+type Response struct {
+	Message string
+	Data    interface{}
+	Errors  interface{}
+}
+
+type APIResponse struct {
+	StatusCode int
+	Response
+}
+
 func NewClient(_ context.Context, apiKey string) (*Client, error) {
 	return &Client{
 		HostURL:  "https://api.statsig.com/console/v1",
@@ -27,9 +38,12 @@ func NewClient(_ context.Context, apiKey string) (*Client, error) {
 	}, nil
 }
 
-// All API calls must include 'STATSIG-API-KEY' in the header. This is the apiKey value
 func (c *Client) Get(endpoint string, queryParams map[string]string) ([]byte, error) {
 	return c.doRequest("GET", endpoint, nil, queryParams)
+}
+
+func (c *Client) Post(endpoint string, requestBody interface{}) ([]byte, error) {
+	return c.doRequest("POST", endpoint, requestBody, nil)
 }
 
 func (c *Client) doRequest(method string, endpoint string, requestBody interface{}, queryParams map[string]string) ([]byte, error) {
@@ -49,10 +63,6 @@ func (c *Client) doRequest(method string, endpoint string, requestBody interface
 	parsedBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, parsedBody)
 	}
 
 	return parsedBody, err

--- a/internal/statsig/statsig_client.go
+++ b/internal/statsig/statsig_client.go
@@ -18,17 +18,6 @@ type Client struct {
 	Client   *http.Client
 }
 
-type Response struct {
-	Message string
-	Data    interface{}
-	Errors  interface{}
-}
-
-type APIResponse struct {
-	StatusCode int
-	Response
-}
-
 func NewClient(_ context.Context, apiKey string) (*Client, error) {
 	return &Client{
 		HostURL:  "https://api.statsig.com/console/v1",

--- a/internal/statsig/statsig_client.go
+++ b/internal/statsig/statsig_client.go
@@ -55,8 +55,11 @@ func (c *Client) doRequest(method string, endpoint string, requestBody interface
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return nil, fmt.Errorf("Failed %s request to %s with status code %d.", method, req.URL, res.StatusCode)
+	switch {
+	case res.StatusCode == 401:
+		return nil, fmt.Errorf("Unauthorized request to %s. Please check your API key.", req.URL)
+	case res.StatusCode < 200 || res.StatusCode >= 300:
+		return nil, fmt.Errorf("Failed to perform request to %s with status code %d.", req.URL, res.StatusCode)
 	}
 	defer res.Body.Close()
 

--- a/internal/statsig/tags.go
+++ b/internal/statsig/tags.go
@@ -3,6 +3,7 @@ package statsig
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -17,6 +18,11 @@ type TagAPIRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	IsCore      bool   `json:"isCore"`
+}
+
+type CreateTagAPIResponse struct {
+	Message string        `json:"message"`
+	Data    TagAPIRequest `json:"data"`
 }
 
 func (c *Client) GetTags(ctx context.Context) ([]TagAPIRequest, error) {
@@ -34,4 +40,26 @@ func (c *Client) GetTags(ctx context.Context) ([]TagAPIRequest, error) {
 	}
 
 	return tagsResponse.Data, nil
+}
+
+func (c *Client) CreateTag(ctx context.Context, tag TagAPIRequest) (*TagAPIRequest, error) {
+	response, err := c.Post("tags", tag)
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Error creating tag: %s", err))
+		return nil, err
+	}
+
+	// Log the response body
+	tflog.Debug(ctx, fmt.Sprintf("Create tag response: %s", response))
+	createdTag := CreateTagAPIResponse{}
+	if err := json.Unmarshal(response, &createdTag); err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Error unmarshalling tag: %s", err))
+		return nil, err
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Returning created tag: %+v", createdTag.Data))
+	tflog.Debug(ctx, fmt.Sprintf("Full response: %+v", createdTag))
+	tflog.Trace(ctx, fmt.Sprintf("Tag created with ID: %s", createdTag.Data.ID))
+
+	return &createdTag.Data, nil
 }

--- a/internal/statsig/tags.go
+++ b/internal/statsig/tags.go
@@ -42,6 +42,24 @@ func (c *Client) GetTags(ctx context.Context) ([]TagAPIRequest, error) {
 	return tagsResponse.Data, nil
 }
 
+func (c *Client) GetTag(ctx context.Context, tagID string) (*TagAPIRequest, error) {
+	// Get all tags and find the one with the matching ID
+	tags, err := c.GetTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var tag TagAPIRequest
+	for _, t := range tags {
+		if t.ID == tagID {
+			tag = t
+			break
+		}
+	}
+
+	return &tag, nil
+}
+
 func (c *Client) CreateTag(ctx context.Context, tag TagAPIRequest) (*TagAPIRequest, error) {
 	response, err := c.Post("tags", tag)
 	if err != nil {


### PR DESCRIPTION
# Pull Request Details

## Related Issues

- Closes #15

## Related PRs

- Requires #17 to be merged in

## What does this PR do?

This PR implements the `Create` and `Read` functionality of the Tags API.

## Description of Changes

- Implement `Create` and `Read` methods to create a tag and validate the current state
- Update Console API Key regex to validate input
- Add logging to provider `Configure` and throughout points of known difficulty
- Add error handling for `401` errors as well in base API calls

---

## Screenshots

### Invalid Console API Key

<img width="632" alt="Screenshot 2024-07-07 at 3 33 34 PM" src="https://github.com/useless-solutions/terraform-provider-statsig/assets/19296809/58bd482b-004c-4e32-92c0-d893504d9d2b">

### Terraform Apply – Unauthorized

<img width="491" alt="Screenshot 2024-07-07 at 3 34 41 PM" src="https://github.com/useless-solutions/terraform-provider-statsig/assets/19296809/f46e2f20-bd91-4285-aaa4-1463425bd7fd">

### Terraform Plan Diff

<img width="631" alt="Screenshot 2024-07-07 at 3 35 08 PM" src="https://github.com/useless-solutions/terraform-provider-statsig/assets/19296809/2b4ee041-83ac-4d24-9409-d3b98c85cf59">
