### PR TITLE
[#24] Prevent `Update` and `Delete` Ops in Tag Resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,13 +73,13 @@ require (
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240709173604-40e1e62336c5 // indirect
+	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -263,10 +263,10 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4 h1:Di6ANFilr+S60a4S61ZM00vLdw0IrQOSMS2/6mrnOU0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
-google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240709173604-40e1e62336c5 h1:SbSDUWW1PAO24TNpLdeheoYPd7kllICcLU52x6eD4kQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240709173604-40e1e62336c5/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
+google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
+google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=

--- a/internal/service/tags/resource.go
+++ b/internal/service/tags/resource.go
@@ -26,7 +26,6 @@ func NewTagResource() resource.Resource {
 	return &TagResource{}
 }
 
-// TagResource defines the resource implementation.
 type TagResource struct {
 	client *statsig.Client
 }
@@ -85,6 +84,11 @@ func (r *TagResource) Configure(ctx context.Context, req resource.ConfigureReque
 	r.client = client
 }
 
+/*
+Create a new tag with the provided attributes.
+
+The ID of the created tag is saved into the Terraform state once the value is returned from the API.
+*/
 func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan Tag
 
@@ -113,14 +117,12 @@ func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	// Update the plan attributes with the tag attributes
-	tflog.Debug(ctx, fmt.Sprintf("Updating plan with created tag. Currently: %+v", plan))
 	plan = Tag{
 		ID:          types.StringValue(tag.ID),
 		Name:        types.StringValue(tag.Name),
 		Description: types.StringValue(tag.Description),
 		IsCore:      types.BoolValue(tag.IsCore),
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Updated plan with created tag. Now: %+v", plan))
 
 	tflog.Trace(ctx, fmt.Sprintf("Tag created with ID: %s", plan.ID))
 
@@ -131,6 +133,9 @@ func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 }
 
+/*
+Read the tag from the API and update the Terraform state with the tag attributes.
+*/
 func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state Tag
 
@@ -141,11 +146,11 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	// Get the tag from the API
-	tag, err := r.client.GetTag(ctx, state.ID.ValueString())
+	tag, err := r.client.GetTag(ctx, state.ID.ValueString()+"fs")
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",
-			fmt.Sprintf("Unable to read tag, got error: %s", err),
+			err.Error(),
 		)
 		return
 	}
@@ -165,50 +170,33 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 }
 
-// TODO: Functionality not supported in API. Will likely delete this.
+/*
+The API does not support updating. This resource is immutable.
+
+If the user wants to change a tag, they should create a new one and manually delete the old one in the Console.
+This is a limitation of the Statsig API.
+
+This method returns an error to the user to inform them of this limitation.
+*/
 func (r *TagResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data statsig.TagAPIRequest
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// If applicable, this is a great opportunity to initialize any necessary
-	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
-	// if err != nil {
-	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, got error: %s", err))
-	//     return
-	// }
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.AddError(
+		"Update Not Supported",
+		"Tags are immutable in the Statsig API. If you need to change a tag, create a new one and manually delete the old one in the Console.",
+	)
 }
 
-// TODO: Functionality not supported in API. Will likely delete this.
 func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data statsig.TagAPIRequest
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// If applicable, this is a great opportunity to initialize any necessary
-	// provider client data and make a call using it.
-	// httpResp, err := r.client.Do(httpReq)
-	// if err != nil {
-	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete example, got error: %s", err))
-	//     return
-	// }
+	// The API does not support deleting. This resource is immutable.
+	// If the user wants to delete a tag, they should do so manually in the Console. Following that, they can remove the tag from the Terraform state.
+	// This is a limitation of the Statsig API.
+	// We will return an error to the user to inform them of this limitation.
+	resp.Diagnostics.AddError(
+		"Delete Not Supported",
+		"Tags are immutable in the Statsig API. If you need to delete a tag, do so manually in the Console. Following that, remove the tag from the Terraform state. Do this using the `terraform state rm` command.",
+	)
 }
 
-// TODO: Need to test this functionality.
+// TODO: Need to implement and test this functionality.
 func (r *TagResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/service/tags/resource.go
+++ b/internal/service/tags/resource.go
@@ -185,11 +185,15 @@ func (r *TagResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	)
 }
 
+/*
+The API does not support deleting. This resource is immutable.
+
+If the user wants to delete a tag, they should do so manually in the Console. Following that, they can remove the tag from the Terraform state.
+This is a limitation of the Statsig API.
+
+We will return an error to the user to inform them of this limitation.
+*/
 func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// The API does not support deleting. This resource is immutable.
-	// If the user wants to delete a tag, they should do so manually in the Console. Following that, they can remove the tag from the Terraform state.
-	// This is a limitation of the Statsig API.
-	// We will return an error to the user to inform them of this limitation.
 	resp.Diagnostics.AddError(
 		"Delete Not Supported",
 		"Tags are immutable in the Statsig API. If you need to delete a tag, do so manually in the Console. Following that, remove the tag from the Terraform state. Do this using the `terraform state rm` command.",

--- a/internal/statsig/tags.go
+++ b/internal/statsig/tags.go
@@ -53,8 +53,15 @@ func (c *Client) GetTag(ctx context.Context, tagID string) (*TagAPIRequest, erro
 	for _, t := range tags {
 		if t.ID == tagID {
 			tag = t
+			tflog.Trace(ctx, fmt.Sprintf("Successfully tag with ID: %s", tagID))
 			break
 		}
+	}
+
+	// Log an error if the the tag is null
+	if tag == (TagAPIRequest{}) {
+		tflog.Error(ctx, fmt.Sprintf("Tag with ID %s not found.", tagID))
+		return nil, fmt.Errorf("Tag with ID '%s' not found.", tagID)
 	}
 
 	return &tag, nil


### PR DESCRIPTION
# Pull Request Details

## Related Issues

- Closes #24 

## Related PRs

Finishes implementation for the `tag` resource created in:

- #20 

## What does this PR do?

This PR implements the `Create` and `Read` functionality of the Tags API.

## Description of Changes

- Set `Update` and `Delete` methods to return an error when invoked
- Document methods with reasoning for API limitations

---

## Screenshots

### Update Prevented

<img width="612" alt="Screenshot 2024-07-10 at 8 55 16 PM" src="https://github.com/useless-solutions/terraform-provider-statsig/assets/19296809/c5a1f737-ae8f-43d7-8e39-a66e279bebbe">

### Delete Prevented

<img width="825" alt="Screenshot 2024-07-10 at 8 55 52 PM" src="https://github.com/useless-solutions/terraform-provider-statsig/assets/19296809/2c82f013-2e4b-44da-b640-d650010e5b3b">
